### PR TITLE
create new common bgc_trip_metadata view

### DIFF
--- a/bgc_data/bgc_phytoplankton_map.sql
+++ b/bgc_data/bgc_phytoplankton_map.sql
@@ -2,26 +2,25 @@
 -- It also provides the metadata columns for all the phytoplankton products.
 CREATE MATERIALIZED VIEW bgc_phytoplankton_map AS
   SELECT
-    projectname AS "Project",
-    stationname AS "StationName",
-    stationcode AS "StationCode",
-    latitude AS "Latitude",
-    longitude AS "Longitude",
-    trip_code AS "TripCode",
-  --  TODO: sampledatelocal AT TIME ZONE "UTC" AS "SampleTime_UTC",
-    sampledatelocal AS "SampleTime_local",
-    extract(year from sampledatelocal)::int AS "Year_local",
-    extract(month from sampledatelocal)::int AS "Month_local",
-    extract(day from sampledatelocal)::int AS "Day_local",
-    to_char(sampledatelocal, 'HH24:MI') AS "Time_local24hr",
+    "Project",
+    "StationName",
+    "StationCode",
+    "Latitude",
+    "Longitude",
+    "TripCode",
+  --  "SampleTime_UTC",
+    "SampleTime_local",
+    "Year_local",
+    "Month_local",
+    "Day_local",
+    "Time_local24hr",
     phytosampledepth_m AS "SampleDepth_m",
-  --  TODO: CTD derived params:
   --  "CTDSST_degC",
   --  "CTDChlaSurf_mgm3",
   --  "CTDSalinity_psu",
     trip_code,
-    st_geomfromtext('POINT(' || longitude::text || ' ' || latitude::text || ')', 4326) AS geom
-  FROM bgc_trip
+    geom
+  FROM bgc_trip_metadata
   WHERE sampletype LIKE '%P%' AND
         trip_code IN (SELECT DISTINCT trip_code from bgc_phyto_raw)
 ;

--- a/bgc_data/bgc_trip_metadata.sql
+++ b/bgc_data/bgc_trip_metadata.sql
@@ -1,0 +1,28 @@
+-- This view provides common trip metadata columns for all bgc products
+CREATE VIEW bgc_trip_metadata AS
+  SELECT
+    projectname AS "Project",
+    stationname AS "StationName",
+    stationcode AS "StationCode",
+    latitude AS "Latitude",
+    longitude AS "Longitude",
+    trip_code AS "TripCode",
+  --  TODO: sampledatelocal AT TIME ZONE "UTC" AS "SampleTime_UTC",
+    sampledatelocal AS "SampleTime_local",
+    extract(year from sampledatelocal)::int AS "Year_local",
+    extract(month from sampledatelocal)::int AS "Month_local",
+    extract(day from sampledatelocal)::int AS "Day_local",
+    to_char(sampledatelocal, 'HH24:MI') AS "Time_local24hr",
+    phytosampledepth_m,
+    zoopsampledepth_m,
+  --  TODO: CTD derived params:
+  --  "CTDSST_degC",
+  --  "CTDChlaSurf_mgm3",
+  --  "CTDSalinity_psu",
+    biomass_mgm3 AS "Biomass_mgm3",
+    secchi_m,
+    sampletype,
+    trip_code,
+    st_geomfromtext('POINT(' || longitude::text || ' ' || latitude::text || ')', 4326) AS geom
+  FROM bgc_trip
+;

--- a/bgc_data/bgc_zooplankton_map.sql
+++ b/bgc_data/bgc_zooplankton_map.sql
@@ -1,28 +1,27 @@
 -- This view is the basis for the WMS layer (seen on step 2 on AODN Portal).
 -- It also provides the metadata columns for all the zooplankton products.
 CREATE MATERIALIZED VIEW bgc_zooplankton_map AS
-SELECT
-    projectname AS "Project",
-    stationname AS "StationName",
-    stationcode AS "StationCode",
-    latitude AS "Latitude",
-    longitude AS "Longitude",
-    trip_code AS "TripCode",
-  --  TODO: sampledatelocal AT TIME ZONE "UTC" AS "SampleTime_UTC",
-    sampledatelocal AS "SampleTime_local",
-    extract(year from sampledatelocal)::int AS "Year_local",
-    extract(month from sampledatelocal)::int AS "Month_local",
-    extract(day from sampledatelocal)::int AS "Day_local",
-    to_char(sampledatelocal, 'HH24:MI') AS "Time_local24hr",
+  SELECT
+    "Project",
+    "StationName",
+    "StationCode",
+    "Latitude",
+    "Longitude",
+    "TripCode",
+  --  "SampleTime_UTC",
+    "SampleTime_local",
+    "Year_local",
+    "Month_local",
+    "Day_local",
+    "Time_local24hr",
     zoopsampledepth_m AS "SampleDepth_m",
-  --  TODO: CTD derived params:
   --  "CTDSST_degC",
   --  "CTDChlaSurf_mgm3",
   --  "CTDSalinity_psu",
-    biomass_mgm3,
+    "Biomass_mgm3",
     trip_code,
-    st_geomfromtext('POINT(' || longitude::text || ' ' || latitude::text || ')', 4326) AS geom
-  FROM bgc_trip
+    geom
+  FROM bgc_trip_metadata
   WHERE sampletype LIKE '%Z%' AND
         trip_code IN (SELECT DISTINCT trip_code from bgc_zoop_raw)
 ;


### PR DESCRIPTION
I've updated the plankon _map views to use the new common view. Once this is merged, the other products could make use of this too.