### PR TITLE
Bgc mods 2021 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.DS_Store

--- a/bgc_data/bgc_chemistry.dataresource.yaml
+++ b/bgc_data/bgc_chemistry.dataresource.yaml
@@ -33,9 +33,6 @@ schema:
     title: "FLAG value"
     type: integer
     required: true
-  - name: SALINITY_COMMENTS
-    type: string
-    required: false
   - name: SILICATE_UMOLL
     title: "Silicate umoll"
     type: number
@@ -72,9 +69,6 @@ schema:
     title: "FLAG value"
     type: integer
     required: true
-  - name: NUTRIENT_COMMENTS
-    type: string
-    required: false
   - name: DIC_UMOLKG
     type: number
     required: false
@@ -82,9 +76,6 @@ schema:
     title: "FLAG value"
     type: integer
     required: true
-  - name: CARBON_COMMENTS
-    type: string
-    required: false
   - name: TALKALINITY_UMOLKG
     type: number
     required: false
@@ -92,9 +83,6 @@ schema:
     title: "FLAG value"
     type: integer
     required: true    
-  - name: ALKALINITY_COMMENTS
-    type: string
-    required: false
   - name: OXYGEN_UMOLL
     type: number
     required: false
@@ -102,9 +90,6 @@ schema:
     title: "FLAG value"
     type: integer
     required: true
-  - name: OXYGEN_COMMENTS
-    type: string
-    required: false
   - name: MICROBIOMESAMPLE_ID
     title: "Microbiomesample_id"
     type: string

--- a/bgc_data/bgc_picoplankton.dataresource.yaml
+++ b/bgc_data/bgc_picoplankton.dataresource.yaml
@@ -14,10 +14,6 @@ schema:
     title: "Identifier for trip"
     type: string
     required: true
-  - name: SAMPLE_CODE
-    title: "Unique identifier for sample"
-    type: string
-    required: true
   - name: SAMPLEDEPTH_M
     title: "Depth (m) that sample was obtained, or 'WC' if combined water-column sample"
     type: string
@@ -28,9 +24,6 @@ schema:
     # format string *must* be specified using standard Python/C strptime specification
     # https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
     format: "%Y-%m-%d %H:%M:%S"
-    required: true
-  - name: REPLICATE
-    type: integer
     required: true
   - name: PROCHLOROCOCCUS_CELLSML
     type: number
@@ -50,61 +43,9 @@ schema:
   - name: PICOEUKARYOTES_FLAG
     type: integer                               
     required: true  
-  - name: PICO_COMMENTS
-    title: "Comments"
-    type: string                               
-    required: false  
-  - name: ANALYSIS_LOCATION
-    title: "Site where sample was analysed"
-    type: string                               
-    required: false  
-  - name: ANALYSIS_DATE
-    title: "Date that sample was analysed (formatted string: YYYY-MM-DD)"
-    type: date
-    format: "%Y-%m-%d"
-    required: false 
-  - name: ANALYST_NAME
-    type: string                               
-    required: false  
-  - name: TEMP_THAWED_DEGC
-    type: number                               
-    required: false  
-  - name: INTERNAL_STANDARD
-    type: string                               
-    required: false  
-  - name: INSTRUMENT_BRAND_MODEL
-    title: "Comments"
-    type: string                               
-    required: false  
-  - name: INSTRUMENT_SERIAL_NUMBER
-    title: "Comments"
-    type: string                               
-    required: false  
-  - name: LASER_NM
-    title: "Comments"
-    type: string                               
-    required: false  
-  - name: MODE_TYPE
-    title: "Comments"
-    type: string                               
-    required: false  
-  - name: ANALYSIS_VOLUME_UL
-    type: number                               
-    required: false  
-  - name: FLOW_RATE_UL_PER_MIN
-    type: integer                               
-    required: false  
-  - name: ANALYSIS_TIME_MINUTES
-    type: integer                               
-    required: false  
-  - name: BATCH_COMMENTS
-    title: "Optional comments on batch process"
-    type: string                               
-    required: false
   primaryKey:
   - TRIP_CODE
   - SAMPLEDEPTH_M
-  - REPLICATE
 licenses:
 - name: CC-BY-4.0
   title: Creative Commons Attribution 4.0

--- a/bgc_data/bgc_picoplankton_meta.dataresource.yaml
+++ b/bgc_data/bgc_picoplankton_meta.dataresource.yaml
@@ -1,0 +1,111 @@
+profile: tabular-data-resource
+name: bgc_picoplankton_meta
+path: https://www.cmar.csiro.au/geoserver/imos/wfs?service=wfs&version=1.1.0&request=GetFeature&outputformat=csv&typename=imos%3Abgc_picoplankton_meta
+title: bgc_picoplankton_meta
+description: "A table of all BGC picoplankton metadata"
+format: csv
+mediatype: text/csv
+encoding: utf-8
+layout:
+  skipFields: [ FID ]
+schema:
+  fields:
+  - name: TRIP_CODE
+    title: "Identifier for trip"
+    type: string
+    required: true
+  - name: SAMPLE_CODE
+    title: "Unique identifier for sample"
+    type: string
+    required: true
+  - name: SAMPLEDEPTH_M
+    title: "Depth (m) that sample was obtained, or 'WC' if combined water-column sample"
+    type: string
+    required: true
+  - name: SAMPLEDATELOCAL
+    title: "Date & time of sample in local time (formatted string)"
+    type: datetime
+    # format string *must* be specified using standard Python/C strptime specification
+    # https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
+    format: "%Y-%m-%d %H:%M:%S"
+    required: true
+  - name: REPLICATE
+    type: integer
+    required: true
+  - name: PROCHLOROCOCCUS_CELLSML
+    type: number
+    required: false  
+  - name: SYNECOCHOCCUS_CELLSML
+    type: number                               
+    required: false  
+  - name: PICOEUKARYOTES_CELLSML
+    type: number                               
+    required: false  
+  - name: PROCHLOROCOCCUS_FLAG
+    type: integer                               
+    required: true  
+  - name: SYNECOCHOCCUS_FLAG
+    type: integer                               
+    required: true  
+  - name: PICOEUKARYOTES_FLAG
+    type: integer                               
+    required: true  
+  - name: PICO_COMMENTS
+    title: "Comments"
+    type: string                               
+    required: false  
+  - name: ANALYSIS_LOCATION
+    title: "Site where sample was analysed"
+    type: string                               
+    required: false  
+  - name: ANALYSIS_DATE
+    title: "Date that sample was analysed (formatted string: YYYY-MM-DD)"
+    type: date
+    format: "%Y-%m-%d"
+    required: false 
+  - name: ANALYST_NAME
+    type: string                               
+    required: false  
+  - name: TEMP_THAWED_DEGC
+    type: number                               
+    required: false  
+  - name: INTERNAL_STANDARD
+    type: string                               
+    required: false  
+  - name: INSTRUMENT_BRAND_MODEL
+    title: "Comments"
+    type: string                               
+    required: false  
+  - name: INSTRUMENT_SERIAL_NUMBER
+    title: "Comments"
+    type: string                               
+    required: false  
+  - name: LASER_NM
+    title: "Comments"
+    type: string                               
+    required: false  
+  - name: MODE_TYPE
+    title: "Comments"
+    type: string                               
+    required: false  
+  - name: ANALYSIS_VOLUME_UL
+    type: number                               
+    required: false  
+  - name: FLOW_RATE_UL_PER_MIN
+    type: integer                               
+    required: false  
+  - name: ANALYSIS_TIME_MINUTES
+    type: integer                               
+    required: false  
+  - name: BATCH_COMMENTS
+    title: "Optional comments on batch process"
+    type: string                               
+    required: false
+  primaryKey:
+  - TRIP_CODE
+  - SAMPLEDEPTH_M
+  - REPLICATE
+licenses:
+- name: CC-BY-4.0
+  title: Creative Commons Attribution 4.0
+  path: https://creativecommons.org/licenses/by/4.0/

--- a/bgc_data/bgc_trip.dataresource.yaml
+++ b/bgc_data/bgc_trip.dataresource.yaml
@@ -57,6 +57,10 @@ schema:
     title: Biomass in mg per m3 for Trip
     type: number
     required: false
+  - name: ASHFREEBIOMASS_MGM3
+    title: Ash Free Biomass in mg per m3 for Trip
+    type: number
+    required: false    
   - name: SECCHI_M
     title: Secchi depth in m for Trip
     type: number

--- a/bgc_data/bgc_tss_meta.dataresource.yaml
+++ b/bgc_data/bgc_tss_meta.dataresource.yaml
@@ -1,8 +1,8 @@
 profile: tabular-data-resource
-name: bgc_tss
-path: https://www.cmar.csiro.au/geoserver/imos/wfs?service=wfs&version=1.1.0&request=GetFeature&outputformat=csv&typename=imos%3Abgc_tss
-title: bgc_tss
-description: "A table of all BGC TSS data"
+name: bgc_tss_meta
+path: https://www.cmar.csiro.au/geoserver/imos/wfs?service=wfs&version=1.1.0&request=GetFeature&outputformat=csv&typename=imos%3Abgc_tss_meta
+title: bgc_tss_meta
+description: "A table of all BGC TSS metadata"
 format: csv
 mediatype: text/csv
 encoding: utf-8
@@ -25,6 +25,10 @@ schema:
     title: "Depth (m) that sample was obtained, or 'WC' if combined water-column sample"
     type: string
     required: true
+  - name: REPLICATE
+    title: "Sample replicate"
+    type: integer
+    required: true
   - name: TSS_MGL
     type: number
     required: false  
@@ -36,10 +40,17 @@ schema:
     required: false 
   - name: TSS_FLAG
     type: integer                               
-    required: true     
+    required: true
+  - name: TSS_COMMENTS
+    type: string                               
+    required: false
+  - name: BLANKADJUSTAVAILABLE
+    type: string                               
+    required: false      
   primaryKey:
   - TRIP_CODE
   - SAMPLEDEPTH_M
+  - REPLICATE
 licenses:
 - name: CC-BY-4.0
   title: Creative Commons Attribution 4.0

--- a/cpr_data/cpr_samp.dataresource.yaml
+++ b/cpr_data/cpr_samp.dataresource.yaml
@@ -18,6 +18,10 @@ schema:
     title: "Unique sample identifier"
     type: string
     required: true  
+  - name: REGION
+    title: "Region identifier"
+    type: string
+    required: true      
   - name: LATITUDE
     title: "Latitude of sampling in decimal degrees North"
     type: number
@@ -46,7 +50,7 @@ schema:
     type: number
     required: false    
   - name: SAMPLETYPE
-    title: ""
+    title: "sample type code"
     type: string
     required: true
   primaryKey: SAMPLE


### PR DESCRIPTION
Hi - I have republished a number of layers on Geoserver, to accomodate changes as advised by @clairedavies.

The main change (other than columns being dropped/added) is that dates are published as dates. Not sure how they will present at your end. I have discussed briefly with @ggalibert , and my understanding is that your preference is for dates to pass through this way (and it is easier for us, as we don't have to specifically format them).

Let me know how this works for you. 
![bgc-2021-12-001](https://user-images.githubusercontent.com/62125066/146475046-5ea366a9-1ca4-42a9-9695-4d0f8abadbd0.jpg)

I have attached a schema diagram of the affected tables - these are presented as layers in geoserver. (Ignore the trailing underscore in the table/layer name in the diagram, this is an artefact of generating the diagram).

Additional note - BGC_PIGMENTS had no changes made, but the others did:
BGC_PICOPLANKTON, BGC_TSS, BGC_CHEMISTRY, BGC_TRIP.
New tables:  BGC_PICOPLANKTON_META, BGC_TSS_META