### PR TITLE
Fix format for SampleTime_local to 24hr time

### DIFF
--- a/bgc_data/bgc_trip_metadata.sql
+++ b/bgc_data/bgc_trip_metadata.sql
@@ -8,7 +8,7 @@ CREATE VIEW bgc_trip_metadata AS
     longitude AS "Longitude",
     trip_code AS "TripCode",
     sampledateutc AS "SampleTime_UTC",
-    to_char(sampledatelocal, 'YYYY-MM-DD HH:MI:SS') AS "SampleTime_local",
+    to_char(sampledatelocal, 'YYYY-MM-DD HH24:MI:SS') AS "SampleTime_local",
     extract(year from sampledatelocal)::int AS "Year_local",
     extract(month from sampledatelocal)::int AS "Month_local",
     extract(day from sampledatelocal)::int AS "Day_local",


### PR DESCRIPTION
A small detail we missed - the timestamp should be formatted using 24-hour times, but in the SQL `to_char` function, "HH" specifies 12-hour times... (see https://www.postgresql.org/docs/10/functions-formatting.html#FUNCTIONS-FORMATTING-DATETIME-TABLE)