### PR TITLE
add methods to bgc_phyto_raw.dataresource.yaml

### DIFF
--- a/bgc_data/bgc_phyto_raw.dataresource.yaml
+++ b/bgc_data/bgc_phyto_raw.dataresource.yaml
@@ -61,6 +61,7 @@ schema:
   primaryKey:
   - TRIP_CODE
   - TAXON_NAME
+  - METHODS
 licenses:
 - name: CC-BY-4.0
   title: Creative Commons Attribution 4.0


### PR DESCRIPTION
This fixes the most recent error that found duplicates for `SOTS_RAS_SOFS10_2021_20220407` as there are not duplicates but have different measurement methods. This should be all we need. Tested harvesting in Leo's stack. 
'methods' is already in:
- bgc_phytoplankton_biovolume_raw_data.sql 
- bgc_phytoplankton_biovolume_htg_data.sql
- bgc_phytoplankton_biovolume_genus_data.sql
- bgc_phytoplankton_biovolume_species_data.sql
- bgc_phytoplankton_abundance_raw_data.sql
- bgc_phytoplankton_abundance_htg_data.sql
- bgc_phytoplankton_abundance_genus_data.sql
- bgc_phytoplankton_abundance_species_data.sql