### PR TITLE
atacoustic schema check relax rule

### DIFF
--- a/IMOS_ATF-ACOUSTIC/IMOS_ATF-ACOUSTIC.schema.yaml
+++ b/IMOS_ATF-ACOUSTIC/IMOS_ATF-ACOUSTIC.schema.yaml
@@ -97,7 +97,6 @@ fields:
     constraints: {'required': True}
   - type: string
     name: transmitter_serial_number
-    constraints: {'required': True}
   - type: integer
     name: transmitter_estimated_battery_life
   - type: string


### PR DESCRIPTION
Due to bad data entry (on a few old transmitters), the facility agreed to relax the rule for the `transmitter_serial_number` and allow `NULL` for this field