### PR TITLE
update SQL to include VBMs in NRS station

### DIFF
--- a/bgc_data/nrs_depth_binned_ctd_map.sql
+++ b/bgc_data/nrs_depth_binned_ctd_map.sql
@@ -7,23 +7,15 @@ WITH nrs_trips AS (
       SELECT
          trip_code,
          sampledateutc,
-         CONCAT(projectname, stationcode) AS site_code
-      FROM bgc_trip
+         -- Manually adjust site code for VBM station
+         CASE
+             WHEN stationcode = 'VBM' THEN 'VBM100'
+             ELSE CONCAT(projectname, stationcode)
+         END AS site_code
+      FROM imos_bgc_db.bgc_trip
       WHERE projectname = 'NRS'
 ),
---transform manually site code for VBM station
-dp_transformed AS (
-      SELECT
-          file_id,
-          time_coverage_start,
-          site_code,
-          CASE
-              WHEN site_code = 'VB1M00' THEN 'NRSVBM'
-              ELSE site_code
-          END AS adjusted_site_code
-      FROM anmn_nrs_ctd_profiles.deployments
-),
---calculate the absolute time difference
+--calculate the absolute time difference 
 --match the site code and time
 ctd_profiles AS (
       SELECT
@@ -33,10 +25,10 @@ ctd_profiles AS (
          GREATEST((nt.sampledateutc - dp.time_coverage_start AT TIME ZONE 'UTC'),
                   -(nt.sampledateutc - dp.time_coverage_start AT TIME ZONE 'UTC'))
              AS absolute_time_difference
-      FROM nrs_trips nt INNER JOIN dp_transformed dp
-         ON dp.adjusted_site_code = nt.site_code
-         AND dp.time_coverage_start AT TIME ZONE 'UTC' BETWEEN (nt.sampledateutc - INTERVAL '1' DAY) AND
-                                                               (nt.sampledateutc + INTERVAL '1' DAY)
+      FROM nrs_trips nt INNER JOIN anmn_nrs_ctd_profiles.deployments dp
+         ON dp.time_coverage_start AT TIME ZONE 'UTC' BETWEEN (nt.sampledateutc - INTERVAL '1' DAY) AND
+                                                              (nt.sampledateutc + INTERVAL '1' DAY)
+         AND dp.site_code = nt.site_code
 ),
 --for each trip, pick the cast that is closest in time
 matched_profiles AS (
@@ -62,4 +54,3 @@ matched_profiles AS (
       FROM bgc_trip_metadata bt
          INNER JOIN matched_profiles mp USING (trip_code)
 ;
-

--- a/bgc_data/nrs_depth_binned_ctd_map.sql
+++ b/bgc_data/nrs_depth_binned_ctd_map.sql
@@ -18,7 +18,7 @@ dp_transformed AS (
           time_coverage_start,
           site_code,
           CASE
-              WHEN site_code LIKE 'VB%' THEN 'NRSVBM'
+              WHEN site_code = 'VB1M00' THEN 'NRSVBM'
               ELSE site_code
           END AS adjusted_site_code
       FROM anmn_nrs_ctd_profiles.deployments


### PR DESCRIPTION
This should fix the issue but it is not a very clean solution. In `anmn_nrs_ctd_profiles` the `site_code` table has a different format for `VBM` as it is not recognised as an NRS station. Thus, I decided to use `VB%` because I'm not sure in the future there will not be any new site code, other option will be to hardcode `VBM100` `VB1S1` `VB1S2` `VB1S4` `VB1S5` that are the site_codes we have so far..