### PR TITLE
fix time format optional

### DIFF
--- a/IMOS_ATF-ACOUSTIC/IMOS_ATF-ACOUSTIC_summaryQC.resource.yaml
+++ b/IMOS_ATF-ACOUSTIC/IMOS_ATF-ACOUSTIC_summaryQC.resource.yaml
@@ -57,7 +57,7 @@ schema:
       type: string
       constraints:
         required: true
-        pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$' 
+        pattern: '^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}Z)?$'
     - name: transmitter_sensor_type
       type: string
       constraints: {'required': true}
@@ -91,12 +91,12 @@ schema:
       type: string
       constraints:
         required: true
-        pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$' 
+        pattern: '^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}Z)?$'
     - name: receiver_recovery_datetime_UTC
       type: string
       constraints:
         required: true
-        pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'
+        pattern: '^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}Z)?$'
     - name: receiver_deployment_longitude
       type: number
       constraints: {'required': true}


### PR DESCRIPTION
making the time part optional on some metadata datetime fields, as these 3 fields don't always have a time entered